### PR TITLE
Require `names` explicitly

### DIFF
--- a/youdao-dictionary.el
+++ b/youdao-dictionary.el
@@ -42,6 +42,7 @@
 (require 'url)
 (require 'org)
 (require 'chinese-word-at-point)
+(require 'names)
 (require 'popup)
 
 (defgroup youdao-dictionary nil

--- a/youdao-dictionary.el
+++ b/youdao-dictionary.el
@@ -42,8 +42,10 @@
 (require 'url)
 (require 'org)
 (require 'chinese-word-at-point)
-(require 'names)
 (require 'popup)
+
+(eval-when-compile
+  (require 'names))
 
 (defgroup youdao-dictionary nil
   "Youdao dictionary interface for Emacs."


### PR DESCRIPTION
Seems to be necessary for `define-namespace` to be properly understood.

Installed the package via MELPA Stable, and without this patch I get the following when I try to run `youdao-dictionary-search-at-point`:

```
void-variable youdao-dictionary-
```
