### PR TITLE
quit-window instead of bury-buffer

### DIFF
--- a/youdao-dictionary.el
+++ b/youdao-dictionary.el
@@ -164,7 +164,7 @@ i.e. `[语][计] dictionary' => 'dictionary'."
         ;; Add Buffer Local Keys
         ;; (see http://www.emacswiki.org/emacs/BufferLocalKeys)
         (use-local-map (copy-keymap org-mode-map))
-        (local-set-key "q" 'bury-buffer)
+        (local-set-key "q" 'quit-window)
         (switch-to-buffer-other-window buffer-name))
     (message "Nothing to look up")))
 


### PR DESCRIPTION
每次查询单词按q退出后　基本都需要用C-x 0 来关闭出现的窗口。　
使用quit-window或者delete-window在大多数情况下更合适。