### PR TITLE
Posframe

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,11 +12,11 @@ Install =youdao-dictionary= from [[http://melpa.org/][MELPA]] with:
 =M-x package-install RET youdao-dictionary RET=
 
 ** Usage
-
+- =youdao-dictionary-search-at-point-= :: Search word at point and display result
+     with given function, default to be =youdao-dictionary-tip-function=. This
+  is the recommended function to use
 - =youdao-dictionary-search-at-point= :: Search word at point and display result
      with buffer
-- =youdao-dictionary-search-at-point-= :: Search word at point and display result
-     with given function, default to be =youdao-dictionary-tip-function=
 - =youdao-dictionary-search-at-point+= :: Search word at point and display
      result with popup-tip
 - =youdao-dictionary-search-at-point-posframe= :: Search word at point and display
@@ -29,8 +29,12 @@ Install =youdao-dictionary= from [[http://melpa.org/][MELPA]] with:
 - =youdao-dictionary-play-voice-from-input= :: Play voice of word from input (by [[https://github.com/snyh][@snyh]])
 
 ** Customization
-   - =youdao-dictionary-tip-function= :: Which function to use to show results, default to be =youdao-dictionary--posframe-tip=, which uses =posframe=. Other possible choices are =youdao-dictionary--pos-tip= for using =pos-tip=, and =popup-tip= for using =popup-tip=
-   - =youdao-dictionary-posframe-tip-face= :: Face for posframe buffer, defaut to inherit =tooltip=
+- =youdao-dictionary-tip-function= :: Which function to use to show results.
+  Possible choices are:
+  | ~youdao-dictionary--posframe-tip~ | uses =posframe=, default when =posframe= is available    |
+  | ~youdao-dictionary--pos-tip~      | uses =pos-tip=, default when =posframe= is not available |
+  | ~popup-tip~                       | uses =popup-tip=                                         |
+- =youdao-dictionary-posframe-tip-face= :: Face for posframe buffer, defaut to inherit =tooltip=
 
 ** Sample configuration
 
@@ -39,7 +43,7 @@ Install =youdao-dictionary= from [[http://melpa.org/][MELPA]] with:
 (setq url-automatic-caching t)
 
 ;; Example Key binding
-(global-set-key (kbd "C-c y") 'youdao-dictionary-search-at-point)
+(global-set-key (kbd "C-c y") 'youdao-dictionary-search-at-point-)
 
 ;; Integrate with popwin-el (https://github.com/m2ym/popwin-el)
 ;; (push "*Youdao Dictionary*" popwin:special-display-config)

--- a/README.org
+++ b/README.org
@@ -12,13 +12,12 @@ Install =youdao-dictionary= from [[http://melpa.org/][MELPA]] with:
 =M-x package-install RET youdao-dictionary RET=
 
 ** Usage
-- =youdao-dictionary-search-at-point-= :: Search word at point and display result
-     with given function, default to be =youdao-dictionary-tip-function=. This
-  is the recommended function to use
 - =youdao-dictionary-search-at-point= :: Search word at point and display result
      with buffer
 - =youdao-dictionary-search-at-point+= :: Search word at point and display
      result with popup-tip
+- =youdao-dictionary-search-at-point-tooltip= :: Search word at point and display
+     result with tooltip
 - =youdao-dictionary-search-at-point-posframe= :: Search word at point and display
      result with posframe
 - =youdao-dictionary-search-from-input= :: Search word from input and display
@@ -29,11 +28,6 @@ Install =youdao-dictionary= from [[http://melpa.org/][MELPA]] with:
 - =youdao-dictionary-play-voice-from-input= :: Play voice of word from input (by [[https://github.com/snyh][@snyh]])
 
 ** Customization
-- =youdao-dictionary-tip-function= :: Which function to use to show results.
-  Possible choices are:
-  | ~youdao-dictionary--posframe-tip~ | uses =posframe=, default when =posframe= is available    |
-  | ~youdao-dictionary--pos-tip~      | uses =pos-tip=, default when =posframe= is not available |
-  | ~popup-tip~                       | uses =popup-tip=                                         |
 - =youdao-dictionary-posframe-tip-face= :: Face for posframe buffer, defaut to inherit =tooltip=
 
 ** Sample configuration

--- a/README.org
+++ b/README.org
@@ -15,14 +15,22 @@ Install =youdao-dictionary= from [[http://melpa.org/][MELPA]] with:
 
 - =youdao-dictionary-search-at-point= :: Search word at point and display result
      with buffer
+- =youdao-dictionary-search-at-point-= :: Search word at point and display result
+     with given function, default to be =youdao-dictionary-tip-function=
 - =youdao-dictionary-search-at-point+= :: Search word at point and display
      result with popup-tip
+- =youdao-dictionary-search-at-point-posframe= :: Search word at point and display
+     result with posframe
 - =youdao-dictionary-search-from-input= :: Search word from input and display
      result with buffer
 - =youdao-dictionary-search-and-replace= :: Search word at point and display
      result with popup-menu, replace word with selected translation.
 - =youdao-dictionary-play-voice-at-point= :: Play voice of word at point (by [[https://github.com/snyh][@snyh]])
 - =youdao-dictionary-play-voice-from-input= :: Play voice of word from input (by [[https://github.com/snyh][@snyh]])
+
+** Customization
+   - =youdao-dictionary-tip-function= :: Which function to use to show results, default to be =youdao-dictionary--posframe-tip=, which uses =posframe=. Other possible choices are =youdao-dictionary--pos-tip= for using =pos-tip=, and =popup-tip= for using =popup-tip=
+   - =youdao-dictionary-posframe-tip-face= :: Face for posframe buffer, defaut to inherit =tooltip=
 
 ** Sample configuration
 

--- a/youdao-dictionary.el
+++ b/youdao-dictionary.el
@@ -50,8 +50,7 @@
 (require 'chinese-word-at-point)
 (require 'popup)
 (require 'pos-tip)
-(unless (version< emacs-version "26.1")
-  (require 'posframe))
+(require 'posframe nil t)
 (eval-when-compile (require 'names))
 
 (defgroup youdao-dictionary nil

--- a/youdao-dictionary.el
+++ b/youdao-dictionary.el
@@ -49,8 +49,9 @@
 (require 'org)
 (require 'chinese-word-at-point)
 (require 'popup)
-(require 'posframe)
 (require 'pos-tip)
+(unless (version< emacs-version "26.1")
+  (require 'posframe))
 (eval-when-compile (require 'names))
 
 (defgroup youdao-dictionary nil
@@ -85,13 +86,17 @@
 See URL `https://github.com/xuchunyang/chinese-word-at-point.el' for more info."
   :type 'boolean)
 
-(defcustom tip-function #'-posframe-tip
-  "Tooltip to use for displaying, default to youdao-dictionary-posframe-tip.
+(defcustom tip-function
+  (if (version< emacs-version "26.1")
+      #'-pos-tip
+    #'-posframe-tip)
+  "Tooltip to use for displaying.
 
- Other possible choices are:
- yaoudao-dictionary--posframe-tip for posframe,
- youdao-dictionary--pos-tip for pos-tip,
- and popup-tip for popup-tip."
+Default to youdao-dictionary--posframe-tip, or youdao-dictionary--postip if
+posframe is not available. Other possible choices are:
+yaoudao-dictionary--posframe-tip for posframe,
+youdao-dictionary--pos-tip for pos-tip, and
+popup-tip for popup-tip."
   :type 'function
   :group 'youdao-dictionary)
 
@@ -239,9 +244,12 @@ i.e. `[语][计] dictionary' => 'dictionary'."
 
 :autoload
 (defun search-at-point- (&optional func)
-  "Search word at point and display result with given func."
+  "Search word at point and display result with given FUNC.
+
+When FUNC is nil, uses youdao-dictionary-tip-function."
   (interactive)
   (let ((word (-region-or-word)))
+    (setq func (or func tip-function))
     (if word
         (funcall func (-format-result word))
       (message "Nothing to look up"))))


### PR DESCRIPTION
Resolve #30 by making a unifying framework for look up words, and add support for using `posframe`. Comparing with existing pull requests, #26 needs to manually toggle posframe buffer, and #32 uses `post-command-hook` to delete posframe buffer when a command is called. This implementation follows existing implementation in `youdao-dictionary--pos-tip`, and uses `(read-event)`. It may be a better and cleaner choice.