### PR TITLE
Support pdf-view-mode when there are no active regions

### DIFF
--- a/youdao-dictionary.el
+++ b/youdao-dictionary.el
@@ -201,7 +201,8 @@ i.e. `[语][计] dictionary' => 'dictionary'."
 (defun -region-or-word ()
   "Return word in region or word at point."
   (if (derived-mode-p 'pdf-view-mode)
-      (mapconcat 'identity (pdf-view-active-region-text) "\n")
+      (if (pdf-view-active-region-p)
+          (mapconcat 'identity (pdf-view-active-region-text) "\n"))
     (if (use-region-p)
         (buffer-substring-no-properties (region-beginning)
                                         (region-end))


### PR DESCRIPTION
Currently, when we run `youdao-dictionary-search-from-input` in `pdf-view-mode`, there will be an error: `The region is not active`.
This pull request allow us to input the word for `youdao dictionary` when there are no active regions.