### PR TITLE
fix current frame loses focus

### DIFF
--- a/youdao-dictionary.el
+++ b/youdao-dictionary.el
@@ -275,7 +275,9 @@ i.e. `[语][计] dictionary' => 'dictionary'."
                          :internal-border-width 1)
           (unwind-protect
               (push (read-event) unread-command-events)
-            (posframe-delete buffer-name)))
+            (progn
+              (posframe-delete buffer-name)
+              (other-frame 0))))
       (message "Nothing to look up"))))
 
 (defun play-voice-of-current-word ()


### PR DESCRIPTION
使用 `youdao-dictionary-search-at-point-posframe` 翻译后，如果不用 `C-g` 关闭 posframe 的话会使当前 frame 失去焦点