### PR TITLE
Process input text in `youdao-dictionary-search-at-point-`

### DIFF
--- a/youdao-dictionary.el
+++ b/youdao-dictionary.el
@@ -325,7 +325,6 @@ i.e. `[语][计] dictionary' => 'dictionary'."
 ;;         ...
 ;;       )
 ;; '''
-:autoload
 (defun replace-unnecessary-string (text regexp-replace-list)
   "Sequncely match and replace text by regexp-replace-list"
   (if text ;; unless => if


### PR DESCRIPTION
获取输入时，把行首的注释和行未的转行替换掉，避免翻译的不连贯。